### PR TITLE
support survey popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,18 @@
       "type": "object",
       "title": "Terraform",
       "properties": {
+        "azapi.survey": {
+          "surveyPromptDate": {
+            "type": "string",
+            "default": "none",
+            "description": "Date of the AzAPI survey will be prompted to the user"
+          },
+          "surveyPromptIgnoredCount": {
+            "type": "number",
+            "default": 0,
+            "description": "Number of times the survey prompt has been ignored"
+          }
+        },
         "azapi.languageServer": {
           "type": "object",
           "description": "Language Server settings",
@@ -121,6 +133,10 @@
       {
         "command": "azapi.disableLanguageServer",
         "title": "Terraform AzApi Provider: Disable Language Server"
+      },
+      {
+        "command": "azapi.showSurvey",
+        "title": "Terraform AzApi Provider: Show Survey"
       }
     ],
     "menus": {},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import { ClientHandler } from './clientHandler';
 import { ServerPath } from './serverPath';
 import { config } from './vscodeUtils';
+import { ShouldShowSurvey, ShowSurvey } from './survey';
 
 const brand = `Terraform AzApi Provider`;
 const outputChannel = vscode.window.createOutputChannel(brand);
@@ -41,6 +42,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await config('azapi').update('languageServer', currentConfig, vscode.ConfigurationTarget.Global);
         stopLanguageServer();
       }
+    }),
+    vscode.commands.registerCommand('azapi.showSurvey', async () => {
+      ShowSurvey();
     }),
     vscode.workspace.onDidChangeTextDocument(async (event: vscode.TextDocumentChangeEvent) => {
       if (event.document.languageId !== 'terraform') {
@@ -90,7 +94,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
-      if (event.affectsConfiguration('azapi')) {
+      if (event.affectsConfiguration('azapi.languageServer')) {
         const reloadMsg = 'Reload VSCode window to apply language server changes';
         const selected = await vscode.window.showInformationMessage(reloadMsg, 'Reload');
         if (selected === 'Reload') {
@@ -102,6 +106,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   if (enabled()) {
     startLanguageServer();
+  }
+
+  if (await ShouldShowSurvey()) {
+    ShowSurvey();
   }
 }
 

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import { config } from './vscodeUtils';
+
+export async function ShouldShowSurvey(): Promise<boolean> {
+  var currentConfig: any = config('azapi').get('survey');
+  if (
+    currentConfig == undefined ||
+    currentConfig.surveyPromptDate == undefined ||
+    currentConfig.surveyPromptDate == 'none'
+  ) {
+    currentConfig = {};
+    // first time, remind after 10 days
+    var promptDate = new Date();
+    promptDate.setDate(promptDate.getDate() + 10);
+    currentConfig.surveyPromptDate = promptDate.toISOString();
+    currentConfig.surveyPromptIgnoredCount = 0;
+    await config('azapi').update('survey', currentConfig, vscode.ConfigurationTarget.Global);
+    return false;
+  }
+
+  if (currentConfig.surveyPromptDate == 'never') {
+    return false;
+  }
+
+  var currentDate = new Date();
+  var promptDate = new Date(currentConfig.surveyPromptDate);
+  if (currentDate >= promptDate) {
+    return true;
+  }
+
+  return false;
+}
+
+export async function ShowSurvey(): Promise<void> {
+  const reloadMsg =
+    'Looks like you are using Terraform AzAPI Provider. We’d love to hear from you! Could you help us improve product usability by filling out a 2-3 minute survey about your experience with it?';
+  const selected = await vscode.window.showInformationMessage(reloadMsg, 'Yes', 'Not Now', 'Never');
+  var currentConfig: any = config('azapi').get('survey');
+  if (currentConfig == undefined) {
+    currentConfig = {};
+    currentConfig.surveyPromptDate = 'none';
+    currentConfig.surveyPromptIgnoredCount = 0;
+  }
+
+  switch (selected) {
+    case 'Yes':
+      vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://aka.ms/AzAPI2025'));
+      // reset the survey prompt date and ignored count, remind after 180 days
+      currentConfig.surveyPromptIgnoredCount = 0;
+      var promptDate = new Date();
+      promptDate.setDate(promptDate.getDate() + 180);
+      currentConfig.surveyPromptDate = promptDate.toISOString();
+      break;
+    case 'Never':
+      currentConfig.surveyPromptDate = 'never';
+      currentConfig.surveyPromptIgnoredCount = 0;
+      break;
+    case 'Not Now':
+    case undefined:
+      currentConfig.surveyPromptIgnoredCount++;
+      if (currentConfig.surveyPromptIgnoredCount == 1) {
+        // first time ignore, remind after 7 days
+        var promptDate = new Date();
+        promptDate.setDate(promptDate.getDate() + 7);
+        currentConfig.surveyPromptDate = promptDate.toISOString();
+      } else {
+        // second time ignore, remind after 30 days
+        var promptDate = new Date();
+        promptDate.setDate(promptDate.getDate() + 30);
+        currentConfig.surveyPromptDate = promptDate.toISOString();
+      }
+      break;
+  }
+  await config('azapi').update('survey', currentConfig, vscode.ConfigurationTarget.Global);
+}

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { config } from './vscodeUtils';
 
 export async function ShouldShowSurvey(): Promise<boolean> {
-  var currentConfig: any = config('azapi').get('survey');
+  let currentConfig: any = config('azapi').get('survey');
   if (
     currentConfig == undefined ||
     currentConfig.surveyPromptDate == undefined ||
@@ -10,7 +10,7 @@ export async function ShouldShowSurvey(): Promise<boolean> {
   ) {
     currentConfig = {};
     // first time, remind after 10 days
-    var promptDate = new Date();
+    const promptDate = new Date();
     promptDate.setDate(promptDate.getDate() + 10);
     currentConfig.surveyPromptDate = promptDate.toISOString();
     currentConfig.surveyPromptIgnoredCount = 0;
@@ -22,8 +22,8 @@ export async function ShouldShowSurvey(): Promise<boolean> {
     return false;
   }
 
-  var currentDate = new Date();
-  var promptDate = new Date(currentConfig.surveyPromptDate);
+  const currentDate = new Date();
+  const promptDate = new Date(currentConfig.surveyPromptDate);
   if (currentDate >= promptDate) {
     return true;
   }
@@ -35,21 +35,22 @@ export async function ShowSurvey(): Promise<void> {
   const reloadMsg =
     'Looks like you are using Terraform AzAPI Provider. We’d love to hear from you! Could you help us improve product usability by filling out a 2-3 minute survey about your experience with it?';
   const selected = await vscode.window.showInformationMessage(reloadMsg, 'Yes', 'Not Now', 'Never');
-  var currentConfig: any = config('azapi').get('survey');
+  let currentConfig: any = config('azapi').get('survey');
   if (currentConfig == undefined) {
     currentConfig = {};
     currentConfig.surveyPromptDate = 'none';
     currentConfig.surveyPromptIgnoredCount = 0;
   }
 
+  const nextPromptDate = new Date();
+
   switch (selected) {
     case 'Yes':
       vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://aka.ms/AzAPI2025'));
       // reset the survey prompt date and ignored count, remind after 180 days
       currentConfig.surveyPromptIgnoredCount = 0;
-      var promptDate = new Date();
-      promptDate.setDate(promptDate.getDate() + 180);
-      currentConfig.surveyPromptDate = promptDate.toISOString();
+      nextPromptDate.setDate(nextPromptDate.getDate() + 180);
+      currentConfig.surveyPromptDate = nextPromptDate.toISOString();
       break;
     case 'Never':
       currentConfig.surveyPromptDate = 'never';
@@ -60,14 +61,12 @@ export async function ShowSurvey(): Promise<void> {
       currentConfig.surveyPromptIgnoredCount++;
       if (currentConfig.surveyPromptIgnoredCount == 1) {
         // first time ignore, remind after 7 days
-        var promptDate = new Date();
-        promptDate.setDate(promptDate.getDate() + 7);
-        currentConfig.surveyPromptDate = promptDate.toISOString();
+        nextPromptDate.setDate(nextPromptDate.getDate() + 7);
+        currentConfig.surveyPromptDate = nextPromptDate.toISOString();
       } else {
         // second time ignore, remind after 30 days
-        var promptDate = new Date();
-        promptDate.setDate(promptDate.getDate() + 30);
-        currentConfig.surveyPromptDate = promptDate.toISOString();
+        nextPromptDate.setDate(nextPromptDate.getDate() + 30);
+        currentConfig.surveyPromptDate = nextPromptDate.toISOString();
       }
       break;
   }


### PR DESCRIPTION
This PR adds support for survey popup.
1. The popup can be triggered by vscode command:
![image](https://github.com/user-attachments/assets/bad9d6ae-3bf4-4776-84a1-c137e951c8ed)

2. The popup can also be triggered automatically after user used this version for 10 days.
   1. If user selects "Yes", it will open the survey link.
   2. If users selects "Never", the survey popup will never be triggered automatically.
   3. If users selects "Not now" or dismissed the popup, it will be triggered in 7 days if it's first time to dismiss the popup, and 30 days if not. 
![image](https://github.com/user-attachments/assets/9e69f17b-e108-4abe-ac6e-79c2a345500b)


